### PR TITLE
#75 hide date range

### DIFF
--- a/components/common/StartEndDatePicker.tsx
+++ b/components/common/StartEndDatePicker.tsx
@@ -29,7 +29,9 @@ interface Props {
   values: { start: Date; end: Date };
   onChangeHandler: (key: string) => (date: Date) => void;
   checkboxHandler?: (e) => void;
+  clearDateHandler?: (e) => void;
   views?: Array<DatePickerView>;
+  startClearable?: boolean;
 }
 
 const StartEndDatePicker: React.FC<Props> = ({
@@ -37,6 +39,8 @@ const StartEndDatePicker: React.FC<Props> = ({
   values,
   onChangeHandler,
   checkboxHandler,
+  clearDateHandler,
+  startClearable,
   views = ["year", "month"],
 }) => {
   return (
@@ -56,6 +60,7 @@ const StartEndDatePicker: React.FC<Props> = ({
             views={views}
             minDate={sub(new Date(), { years: 30 })}
             maxDate={add(new Date(), { years: 5 })}
+            clearable={startClearable}
           />
         </Box>
         <Box>
@@ -76,15 +81,27 @@ const StartEndDatePicker: React.FC<Props> = ({
           />
         </Box>
       </HStack>
-      <Checkbox
-        mb="4"
-        size="sm"
-        name="end"
-        onChange={checkboxHandler}
-        isChecked={!values.end}
-      >
-        {labels.checkbox}
-      </Checkbox>
+      <HStack mb="4" spacing="4">
+        {startClearable ? (
+          <Checkbox
+            size="sm"
+            name="start"
+            onChange={clearDateHandler}
+            isChecked={!values.start}
+          >
+            Hide Date
+          </Checkbox>
+        ) : null}
+        <Checkbox
+          size="sm"
+          name="end"
+          onChange={checkboxHandler}
+          isChecked={!values.end}
+          isDisabled={!values.start}
+        >
+          {labels.checkbox}
+        </Checkbox>
+      </HStack>
     </>
   );
 };

--- a/modules/UserInput/Projects/index.tsx
+++ b/modules/UserInput/Projects/index.tsx
@@ -33,6 +33,7 @@ import { getUniqueID } from "../../../utils";
 import Autosave from "../Autosave";
 import {
   handleChange,
+  handleClearDate,
   handleDateChange,
   handleDragEnd,
   handleEditorChange,
@@ -149,6 +150,10 @@ const Projects = () => {
               checkboxHandler={() =>
                 handlePresentCheckbox(index, data[index].end, updateData)
               }
+              clearDateHandler={() =>
+                handleClearDate(index, data[index].start, updateData)
+              }
+              startClearable
             />
             <EditorWithLabel
               onChange={(output) =>

--- a/modules/UserInput/handlers.ts
+++ b/modules/UserInput/handlers.ts
@@ -85,6 +85,30 @@ export const handlePresentCheckbox = (
 };
 
 /**
+ * Toggles the checkbox by controlling the value of the `end` date.
+ * @param index Index of the current object.
+ * @param value Value of "end" or Key to update. Toggles between `null` and Present Date
+ * @param action Callback action to perform. TypeOf `(index: number, key: string, value: any)`
+ * @param key Optional argument to change the key for which the value needs to be updated. Default = "end"
+ * @returns void
+ */
+export const handleClearDate = (
+  index: number,
+  value: Date,
+  action: UpdateAction
+) => {
+  const K1 = "start";
+  const K2 = "end";
+  if (value) {
+    action(index, K1, null);
+    action(index, K2, null);
+  } else {
+    action(index, K1, new Date());
+    action(index, K2, new Date());
+  }
+};
+
+/**
  * Uses string input separated by comma(',') and saves an array as tags.
  * @param e Event Object
  * @param index Index of the current object.

--- a/utils/index.ts
+++ b/utils/index.ts
@@ -86,6 +86,7 @@ export const dateDisplay = (start: Date, end: Date, view: "Y" | "YM" = "Y") => {
   const startDate = new Date(start);
   const endDate = new Date(end);
 
+  if(!start) return null;
   if (isSameMonth(startDate, endDate) && isSameYear(startDate, endDate))
     return parseDate(start, view);
   return `${parseDate(start, view)} - ${parseDate(end, view)}`;


### PR DESCRIPTION
## Changelog
* Allowing `null` values in Start with optional props
* Added Checkbox to set the start date as null
* If the start date is `null` then end date is also set as `null` and the date range is hidden on the resume
* Present checkbox is disabled when Hide Date is active
* Added Clear Date Handler
* Implemented date range clearing in Projects User Input ONLY

![image](https://user-images.githubusercontent.com/30192068/132187651-35ecb9fa-bdd2-4d0a-b0a6-0cd406f2c184.png)

## Note
Since setting end-date as null automatically checks, hence when Hide Date is active, Present will be checked but disabled.

This closes #75 