### PR TITLE
Fix/date mismatch

### DIFF
--- a/modules/UserInput/Certification/index.tsx
+++ b/modules/UserInput/Certification/index.tsx
@@ -28,7 +28,7 @@ import DndWrapper from "../../../components/layouts/DndWrapper";
 import Section from "../../../components/layouts/Section";
 import CertificationHints from "../../../data/Hints/certification";
 import { useCustomToast } from "../../../hooks/useCustomToast";
-import { getUniqueID } from "../../../utils";
+import { getMidMonthDate, getUniqueID } from "../../../utils";
 import Autosave from "../Autosave";
 import {
   handleChange,
@@ -60,8 +60,8 @@ const Certification = () => {
     certificateName: "",
     authority: "",
     credentialNumber: "",
-    start: new Date(),
-    end: new Date(),
+    start: getMidMonthDate(),
+    end: getMidMonthDate(),
     link: ""
   };
 

--- a/modules/UserInput/Custom/CustomSectionControls.tsx
+++ b/modules/UserInput/Custom/CustomSectionControls.tsx
@@ -25,7 +25,7 @@ import TooltipIconButton from "../../../components/common/TooltipIconButton";
 import { useCustomToast } from "../../../hooks/useCustomToast";
 import { useDisabled } from "../../../hooks/useDisabled";
 import useResumeStore from "../../../store/resume.store";
-import { getUniqueID, toCamelCase } from "../../../utils";
+import { getMidMonthDate, getUniqueID, toCamelCase } from "../../../utils";
 import SectionControls from "../SectionControls";
 import { useCustomSectionStore } from "./store";
 import {
@@ -45,7 +45,7 @@ const getDefaultValue = (type: CustomSectionInputObject["type"]) => {
     case "DESC":
       return "";
     case "DATE":
-      return { start: new Date(), end: new Date() };
+      return { start: getMidMonthDate(), end: getMidMonthDate() };
   }
 };
 

--- a/modules/UserInput/Custom/CustomSectionInputs.tsx
+++ b/modules/UserInput/Custom/CustomSectionInputs.tsx
@@ -25,7 +25,7 @@ import { patchCustomSections } from "../../../apis/patchSection";
 import ExpandableCard from "../../../components/layouts/Cards/ExpandableCard";
 import DndWrapper from "../../../components/layouts/DndWrapper";
 import Section from "../../../components/layouts/Section";
-import { sanitizeHTML, truncateString } from "../../../utils";
+import { getMidMonthDate, sanitizeHTML, truncateString } from "../../../utils";
 import Autosave from "../Autosave";
 import CustomSectionControls from "./CustomSectionControls";
 import { useCustomSectionStore } from "./store";
@@ -76,15 +76,16 @@ const getInputFieldComponent = (
       return (
         <StartEndDatePicker
           values={{ start, end }}
-          onChangeHandler={(key) => (date) =>
+          onChangeHandler={(key) => (date) => {
             updateData(sectionId, dataItem._id, field._id, {
               ...(dateObj as DateValue),
-              [key]: date
+              [key]: getMidMonthDate(date)
             })}
+          }
           checkboxHandler={(e) =>
             updateData(sectionId, dataItem._id, field._id, {
               ...(dateObj as DateValue),
-              end: dateObj.end === null ? new Date() : null
+              end: dateObj.end === null ? getMidMonthDate() : null
             })
           }
         />
@@ -107,7 +108,8 @@ const getInputFieldComponent = (
 
 const getCardTitle = (data: CustomSectionDataObject) => {
   const firstField = Object.keys(data.values)[0];
-  if (typeof firstField !== "string") return "";
+
+  if (typeof data.values[firstField] !== "string") return "";
 
   const returnString = sanitizeHTML(data.values[firstField]);
   return truncateString(returnString, 40);

--- a/modules/UserInput/Education/index.tsx
+++ b/modules/UserInput/Education/index.tsx
@@ -29,7 +29,7 @@ import DndWrapper from "../../../components/layouts/DndWrapper";
 import Section from "../../../components/layouts/Section";
 import EducationHints from "../../../data/Hints/education";
 import { useCustomToast } from "../../../hooks/useCustomToast";
-import { getUniqueID } from "../../../utils";
+import { getMidMonthDate, getUniqueID } from "../../../utils";
 import Autosave from "../Autosave";
 import {
   handleChange,
@@ -69,8 +69,8 @@ const Education = () => {
     stream: "",
     gradeObtained: 1,
     gradeMax: 10,
-    start: new Date(),
-    end: new Date(),
+    start: getMidMonthDate(),
+    end: getMidMonthDate(),
     description: ""
   };
 

--- a/modules/UserInput/Experience/index.tsx
+++ b/modules/UserInput/Experience/index.tsx
@@ -29,7 +29,7 @@ import DndWrapper from "../../../components/layouts/DndWrapper";
 import Section from "../../../components/layouts/Section";
 import ExperienceHints from "../../../data/Hints/experience";
 import { useCustomToast } from "../../../hooks/useCustomToast";
-import { getUniqueID } from "../../../utils";
+import { getMidMonthDate, getUniqueID } from "../../../utils";
 import Autosave from "../Autosave";
 import {
   handleChange,
@@ -65,8 +65,8 @@ const Experience = () => {
     description: "",
     link: "",
     tags: [],
-    start: new Date(),
-    end: new Date(),
+    start: getMidMonthDate(),
+    end: getMidMonthDate(),
     isHidden: false
   };
 

--- a/modules/UserInput/Projects/index.tsx
+++ b/modules/UserInput/Projects/index.tsx
@@ -29,7 +29,7 @@ import DndWrapper from "../../../components/layouts/DndWrapper";
 import Section from "../../../components/layouts/Section";
 import ProjectHints from "../../../data/Hints/projects";
 import { useCustomToast } from "../../../hooks/useCustomToast";
-import { getUniqueID } from "../../../utils";
+import { getMidMonthDate, getUniqueID } from "../../../utils";
 import Autosave from "../Autosave";
 import {
   handleChange,
@@ -63,8 +63,8 @@ const Projects = () => {
     isHidden: false,
     projectName: "",
     additionalInfo: "",
-    start: new Date(),
-    end: new Date(),
+    start: getMidMonthDate(),
+    end: getMidMonthDate(),
     description: "",
     link: "",
     tags: []

--- a/modules/UserInput/handlers.ts
+++ b/modules/UserInput/handlers.ts
@@ -22,6 +22,7 @@ import { Content } from "@tiptap/core";
 import React from "react";
 import { DropResult } from "react-beautiful-dnd";
 import { UpdateAction } from "../../store/types";
+import { getMidMonthDate } from "../../utils";
 
 /**
  * Handles the input element change for the current object using `key:value` pair
@@ -81,7 +82,7 @@ export const handlePresentCheckbox = (
 ) => {
   const K = key || "end";
   if (value) return action(index, K, null);
-  else return action(index, K, new Date());
+  else return action(index, K, getMidMonthDate());
 };
 
 /**
@@ -103,8 +104,8 @@ export const handleClearDate = (
     action(index, K1, null);
     action(index, K2, null);
   } else {
-    action(index, K1, new Date());
-    action(index, K2, new Date());
+    action(index, K1, getMidMonthDate());
+    action(index, K2, getMidMonthDate());
   }
 };
 

--- a/utils/index.ts
+++ b/utils/index.ts
@@ -110,3 +110,17 @@ export const isValidColorHex = (hexCode: string) => {
 export const toCamelCase = (str: string) => {
   return str.charAt(0).toUpperCase() + str.substring(1).toLowerCase();
 };
+
+/**
+ * Get the UTC date for 15th of the current month. ONLY USE FOR INITIALIZING THE DATEPICKER.
+ * @param currentDate Current Date returned from new Date() or JS date object. Pass this param to modify a custom date.
+ * @returns Returns the date in the format of "YYYY-MM-DD" but with 15th of that month and UTC 00:00:00.000 time.
+ */
+export const getMidMonthDate = (currentDate = new Date()): Date => {
+  const now = currentDate;
+
+  const month = now.getMonth() + 1;
+  const year = now.getFullYear();
+
+  return new Date(`${month}/15/${year} 00:00:00.000Z`);
+};


### PR DESCRIPTION
# Description

<!-- Please include a summary of the change and which issue is fixed. Please also have relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #120 (issue)

## Type of change
We were changing the month from the date picker but it was taking the value of the date and the time according to the current browser, then saving it in UTC in the DB. The DB was using those values to print the resume, which was mismatched with the date in the UI due to the time zone difference.

**UI**
```
start: 2021-12-01T00:00:00.000+05:30
```

**DB**
```
start: 2021-11-30T18:30:00.000+00:00
```

Hence in the printed version, the value was different.

The solution was to use the mid-month value for the date and store it in DB and store it in UTC time itself, instead of the local time. This way we can be sure that the date won't slip into a different month accidentally due to UTC to local time zone conversion.

<!-- 
Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] Test A - Try creating a new experience, project, certification, etc. and change the date, then print the resume. The dates will be the same in UI and output.
- [ ] Test B

## Development & Testing Configuration 

<!-- Fill the relevant information as per you. If haven't set up backend delete requirements for same or vice versa.  -->

* node version: 16.x
* react version:
* next version:
* Firebase version:
* Mongoose version:
* MongoDB version:

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have read and agree with [Code of Conduct](https://docs.resuminator.in/docs/legal/code-of-conduct)
- [x] I am a registered user of Resuminator. 

**Email Registered on Resuminator:** vivek@resuminator.in

<!-- This will help us tag contribution to your profile if we planned to do so it in future. -->

## Related PR's (If Any):

