### PR TITLE
fix: spacing issue with compact spacing mode

### DIFF
--- a/modules/Resume/index.tsx
+++ b/modules/Resume/index.tsx
@@ -104,6 +104,29 @@ const ResumePaper = () => {
     }
   };
 
+  const getXspacing = (spacing: number) => {
+    const BASE_SPACING = 1;
+    const SPACE_FACTOR = 4;
+    const SPACE_ADJUSTMENT = 1;
+    const DEFAULT = 3;
+
+    // These adjustments have been made to return spacing as ["0.125rem", chakra-spacing-1, chakra-spacing-2, chakra-spacing-3]
+
+    return spacing >= BASE_SPACING ? (spacing * SPACE_FACTOR - SPACE_ADJUSTMENT) : DEFAULT
+  };
+
+  const getYspacing = (spacing: number) => {
+    const BASE_SPACING = "0.125rem";
+    const SPACE_FACTOR = 2;
+    const SPACE_ADJUSTMENT = 1;
+
+    // These adjustments have been made to return spacing as ["0.125rem", chakra-spacing-1, chakra-spacing-2, chakra-spacing-3]
+
+    const spacingInChakraUnits = spacing * SPACE_FACTOR - SPACE_ADJUSTMENT;
+
+    return spacingInChakraUnits === 0 ? BASE_SPACING : spacingInChakraUnits;
+  }
+
   return (
     <StylePropsProvider>
       <Paper>
@@ -132,8 +155,8 @@ const ResumePaper = () => {
                       flexDir="column"
                       aria-label={`Column-${index + 1}`}
                       index={index}
-                      px={spacing >= 1 ? spacing * 4 - 1 : 3}
-                      py={spacing * 2 - 1}
+                      px={getXspacing(spacing)}
+                      py={getYspacing(spacing)}
                       flexBasis={`${(1 / body.length) * 100}%`}
                       bg={snapshot.isDraggingOver ? dndProps.bg : "inherit"}
                       {...provided.droppableProps}


### PR DESCRIPTION
# Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #139 (issue)

## Type of change
With "compact" spacing, the padding of the second column was becoming 0px. Updated the spacing logic to make it "0.125rem"

<!-- 
Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Test A - Now you can drop a section to second column with compact spacing as well.
- [ ] Test B

## Development & Testing Configuration 

<!-- Fill the relevant information as per you. If haven't set up backend delete requirements for same or vice versa.  -->

* node version: 16.x
* react version:
* next version:
* Firebase version:
* Mongoose version:
* MongoDB version:

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have read and agree with [Code of Conduct](https://docs.resuminator.in/docs/legal/code-of-conduct)
- [x] I am a registered user of Resuminator. 

**Email Registered on Resuminator:** vivek@resuminator.in

<!-- This will help us tag contribution to your profile if we planned to do so it in future. -->

## Related PR's (If Any):
N/A
