### PR TITLE
fix: fixing safari issue while parsing date

### DIFF
--- a/utils/index.ts
+++ b/utils/index.ts
@@ -122,5 +122,5 @@ export const getMidMonthDate = (currentDate = new Date()): Date => {
   const month = now.getMonth() + 1;
   const year = now.getFullYear();
 
-  return new Date(`${month}/15/${year} 00:00:00.000Z`);
+  return new Date(`${month}/15/${year} 00:00:00 UTC`);
 };


### PR DESCRIPTION
# Description

There is a known issue [date-fns#2130](https://github.com/date-fns/date-fns/issues/2130) with Safari for date-fns that throws an error when parsing dates with milliseconds in it. There is a known workaround for it mentioned in the issue thread. This PR implements it to prevent the date picker from breaking on browsers like Safari and Firefox.

Fixes #143 (issue)

## Type of change

<!-- 
Please delete options that are not relevant. -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [X] Test A - Try adding a new item in any section with a date picker like Education, Experience etc and it should not end in a client-side error.
- [ ] Test B

## Development & Testing Configuration 

<!-- Fill the relevant information as per you. If haven't set up backend delete requirements for same or vice versa.  -->

* node version: v16.xx
* react version:
* next version:
* Firebase version:
* Mongoose version:
* MongoDB version:

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have read and agree with [Code of Conduct](https://docs.resuminator.in/docs/legal/code-of-conduct)
- [x] I am a registered user of Resuminator. 

**Email Registered on Resuminator:** vivek@resuminator.in

<!-- This will help us tag contribution to your profile if we planned to do so it in future. -->

## Related PR's (If Any):
N/A
