### PR TITLE
docs: fix broken link to Contribution Guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ You can support the development of this project if you believe this project adde
 
 It's so exciting to see developers, designers, and product enthusiasts willing to contribute to Resuminator! We will soon be open for accepting code contributions to the repository, but this doesn't mean you cannot help us in developing the most efficient and elegant resume builder out there.
 
-There are a few ways you can contribute to Resuminator and its community which you can find in our [Contribution Guide](CONTRIBUTING.md).
+There are a few ways you can contribute to Resuminator and its community which you can find in our [Contribution Guide](https://docs.resuminator.in/docs/developer-guide/contributing).
 
 You can also join our [Discord Server](https://discord.resuminator.in) and participate in [GitHub Discussions](https://github.com/resuminator/resuminator/discussions).
 


### PR DESCRIPTION
# Description

In the README.md file, the link to the Contribution Guide was pointing to a `CONTRIBUTION.md` file that no longer [exists](https://github.com/resuminator/resuminator/blob/main/CONTRIBUTING.md).

> The 'resuminator/resuminator' repository doesn't contain the 'CONTRIBUTING.md' path in 'main'.  

I fixed it with the correct link to the Contribution Guide on the Resuminator docs website.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] I checked the new link and it works. It leads to the Contributing Guidelines page of the Resuminator docs website

## Development & Testing Configuration 

N/A - docs-only fix

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have read and agree with [Code of Conduct](https://docs.resuminator.in/docs/legal/code-of-conduct)
- [x] I am a registered user of Resuminator. 

**Email Registered on Resuminator:** 
